### PR TITLE
feat(captions): add support for inband captions to Partial Transmuxer

### DIFF
--- a/debug/captions.html
+++ b/debug/captions.html
@@ -72,6 +72,10 @@
                 <label><input id="reset-tranmsuxer" type=checkbox name=reset checked value="reset">&nbsp;Recreate the Transmuxer &amp; MediaSource for each file open?
                 </label>
               </div>
+              <div>
+                <label><input id="partial-transmuxer" type=checkbox name=partial value="partial"> Use Partial Transmuxer?
+                </label>
+              </div>
             </fieldset>
             <fieldset>
               <legend>DASH Input</legend>
@@ -265,6 +269,7 @@
             combined = document.querySelector('#combined-output').checked,
             outputType = document.querySelector('input[name="output"]:checked').value,
             resetTransmuxer = $('#reset-tranmsuxer').checked,
+            partial = $('#partial-transmuxer').checked,
             remuxedSegments = [],
             parsedCaptions = [],
             remuxedInitSegment = null,
@@ -276,19 +281,30 @@
         if (resetTransmuxer || !transmuxer) {
           createInitSegment = true;
           if (combined) {
-              outputType = 'combined';
-              transmuxer = new muxjs.mp4.Transmuxer();
-          } else {
-              transmuxer = new muxjs.mp4.Transmuxer({remux: false});
+            outputType = 'combined';
+            transmuxer = new muxjs.mp4.Transmuxer();
+          } else if (!partial) {
+            transmuxer = new muxjs.mp4.Transmuxer({remux: false});
+          } else if (partial) {
+            transmuxer = new muxjs.partial.Transmuxer({remux: false});
           }
 
           transmuxer.on('data', function(event) {
             if (event.type === outputType) {
               remuxedSegments.push(event);
-              parsedCaptions = parsedCaptions.concat(event.captions);
-              remuxedBytesLength += event.data.byteLength;
-              remuxedInitSegment = event.initSegment;
+              if (!partial) {
+                remuxedBytesLength += event.data.byteLength;
+                remuxedInitSegment = event.initSegment;
+                parsedCaptions = parsedCaptions.concat(event.captions);
+              } else {
+                remuxedBytesLength += event.data.boxes.byteLength;
+                remuxedInitSegment = event.data.track.initSegment;
+              }
             }
+          });
+
+          transmuxer.on('captionInfo', function(captionInfo) {
+            parsedCaptions = parsedCaptions.concat(captionInfo.captions);
           });
 
           transmuxer.on('done', function () {
@@ -303,8 +319,16 @@
             }
 
             for (j = 0, i = offset; j < remuxedSegments.length; j++) {
-              bytes.set(remuxedSegments[j].data, i);
-              i += remuxedSegments[j].byteLength;
+              var boxData;
+
+              if (!partial) {
+                boxData = remuxedSegments[j].data;
+              } else {
+                boxData = remuxedSegments[j].data.boxes;
+              }
+
+              bytes.set(boxData, i);
+              i += boxData.byteLength;
             }
             remuxedSegments = [];
             remuxedBytesLength = 0;

--- a/debug/captions.html
+++ b/debug/captions.html
@@ -309,8 +309,6 @@
           return;
         }
 
-        console.log('done');
-
         if (createInitSegment) {
           bytes = new Uint8Array(remuxedInitSegment.byteLength + remuxedBytesLength)
           bytes.set(remuxedInitSegment, offset);
@@ -320,11 +318,10 @@
           bytes = new Uint8Array(remuxedBytesLength);
         }
 
-        var i;
         for (var j = 0, i = offset; j < remuxedSegments.length; j++) {
           var boxData = partial ?
-             boxData = remuxedSegments[j].data.boxes :
-             boxData = remuxedSegments[j].data;
+            remuxedSegments[j].data.boxes :
+            remuxedSegments[j].data;
 
           bytes.set(boxData, i);
           i += boxData.byteLength;

--- a/debug/captions.html
+++ b/debug/captions.html
@@ -295,7 +295,6 @@
               if (!partial) {
                 remuxedBytesLength += event.data.byteLength;
                 remuxedInitSegment = event.initSegment;
-                parsedCaptions = parsedCaptions.concat(event.captions);
               } else {
                 remuxedBytesLength += event.data.boxes.byteLength;
                 remuxedInitSegment = event.data.track.initSegment;
@@ -319,13 +318,9 @@
             }
 
             for (j = 0, i = offset; j < remuxedSegments.length; j++) {
-              var boxData;
-
-              if (!partial) {
-                boxData = remuxedSegments[j].data;
-              } else {
-                boxData = remuxedSegments[j].data.boxes;
-              }
+              var boxData = partial ?
+                 boxData = remuxedSegments[j].data.boxes :
+                 boxData = remuxedSegments[j].data;
 
               bytes.set(boxData, i);
               i += boxData.byteLength;
@@ -408,6 +403,7 @@
       dashParsed = captionParser.parse(segmentBytes, videoTrackIds, timescales);
 
       dashBoxes.innerHTML = JSON.stringify(dashParsed, null, 2);
+      console.log('captions', dashParsed.captions);
       captionParser.reset();
     });
 

--- a/debug/captions.html
+++ b/debug/captions.html
@@ -346,7 +346,11 @@
         }
 
         transmuxer.push(segment);
-        transmuxer.flush();
+        if (!partial) {
+          transmuxer.flush();
+        } else {
+          transmuxer.partialFlush();
+        }
       });
 
       muxedName = this.files[0].name.replace('.ts', '.f4m');

--- a/debug/captions.html
+++ b/debug/captions.html
@@ -303,8 +303,8 @@
             }
           });
 
-          transmuxer.on('captionInfo', function(captionInfo) {
-            parsedCaptions = parsedCaptions.concat(captionInfo.captions);
+          transmuxer.on('caption', function(caption) {
+            parsedCaptions = parsedCaptions.concat(caption);
           });
 
           transmuxer.on('done', function () {
@@ -338,6 +338,7 @@
 
             // clear old box info
             dashBoxes.innerHTML = JSON.stringify(parsedCaptions, null, 2);
+            console.log('captions', parsedCaptions);
 
             if ($('#m2ts-active').checked) {
               prepareSourceBuffer(combined, outputType, function () {

--- a/debug/captions.html
+++ b/debug/captions.html
@@ -56,6 +56,7 @@
                   <input type="file" id="m2ts">
                 </label>
                 <button id="save-muxed" type="button">Save Transmuxer Output</button>
+                <button id="clear-muxed" type="button">Clear Selection</button>
               </div>
               <div>
                 <label><input id="combined-output" type=checkbox name=combined checked value="combined">&nbsp;Remux output into a single output?
@@ -97,7 +98,13 @@
                   <input type="file" id="dash-media">
                 </label>
               </div>
+              <div>
+                <label>
+                  <input type="checkbox" id="dash-partial"> Is this partial data?
+                </label>
+              </div>
               <button id="parse-dash" type="button">Parse Captions</button>
+              <button id="clear-dash" type="button">Clear Selections</button>
             </fieldset>
             <div>
               <label>
@@ -139,6 +146,9 @@
       $ = document.querySelector.bind(document),
       inputs = $('#inputs'),
       m2ts = $('#m2ts'),
+      dashInit = $('#dash-init'),
+      dashMedia = $('#dash-media'),
+      parseDash = $('#parse-dash'),
       captionParser = new muxjs.mp4.CaptionParser(),
       probe = muxjs.mp4.probe,
 
@@ -162,7 +172,11 @@
       prepareSourceBuffer;
 
     logevent = function(event) {
-      console.log(event.type);
+      if (event.type === 'error') {
+        console.error(event.type, event.target.error ? event.target.error : '');
+      } else {
+        console.log(event.type);
+      }
     };
 
     saveTA = function(tarr, n) { var b = new Blob([tarr], {type: 'application/octet-binary'}); return window.saveAs(b, n);}
@@ -257,26 +271,89 @@
 
     m2ts.addEventListener('change', function() {
       var reader = new FileReader();
+      var remuxedSegments = [];
+      var parsedCaptions = [];
+      var remuxedInitSegment = null;
+      var remuxedBytesLength = 0;
+      var createInitSegment = false;
+      var bytes;
+
+      var combined = document.querySelector('#combined-output').checked;
+      var outputType = document.querySelector('input[name="output"]:checked').value;
+      var resetTransmuxer = $('#reset-tranmsuxer').checked;
+      var partial = $('#partial-transmuxer').checked;
 
       // do nothing if no file was chosen
       if (!this.files[0]) {
         return;
       }
 
-      reader.addEventListener('loadend', function() {
+      var onData = function(event) {
+        if (event.type === outputType) {
+          remuxedSegments.push(event);
 
-        var segment = new Uint8Array(reader.result),
-            combined = document.querySelector('#combined-output').checked,
-            outputType = document.querySelector('input[name="output"]:checked').value,
-            resetTransmuxer = $('#reset-tranmsuxer').checked,
-            partial = $('#partial-transmuxer').checked,
-            remuxedSegments = [],
-            parsedCaptions = [],
-            remuxedInitSegment = null,
-            remuxedBytesLength = 0,
-            createInitSegment = false,
-            bytes,
-            i, j;
+          if (!partial) {
+            remuxedBytesLength += event.data.byteLength;
+            remuxedInitSegment = event.initSegment;
+          } else {
+            remuxedBytesLength += event.data.boxes.byteLength;
+            remuxedInitSegment = event.data.track.initSegment;
+          }
+        }
+      };
+
+      var onDone = function (source) {
+        var offset = 0;
+
+        if (source && !source.toLowerCase().includes(outputType)) {
+          return;
+        }
+
+        console.log('done');
+
+        if (createInitSegment) {
+          bytes = new Uint8Array(remuxedInitSegment.byteLength + remuxedBytesLength)
+          bytes.set(remuxedInitSegment, offset);
+          offset += remuxedInitSegment.byteLength;
+          createInitSegment = false;
+        } else {
+          bytes = new Uint8Array(remuxedBytesLength);
+        }
+
+        var i;
+        for (var j = 0, i = offset; j < remuxedSegments.length; j++) {
+          var boxData = partial ?
+             boxData = remuxedSegments[j].data.boxes :
+             boxData = remuxedSegments[j].data;
+
+          bytes.set(boxData, i);
+          i += boxData.byteLength;
+        }
+        remuxedSegments = [];
+        remuxedBytesLength = 0;
+
+        vjsParsed = muxjs.mp4.tools.inspect(bytes);
+        console.log('transmuxed', vjsParsed);
+
+        // clear old box info
+        dashBoxes.innerHTML = JSON.stringify(parsedCaptions, null, 2);
+        console.log('captions', parsedCaptions);
+
+        if ($('#m2ts-active').checked) {
+          prepareSourceBuffer(combined, outputType, function () {
+            console.log('appending...');
+            window.vjsBuffer.appendBuffer(bytes);
+            video.play();
+          });
+        }
+      };
+
+      var onCaption = function(caption) {
+        parsedCaptions = parsedCaptions.concat(caption);
+      };
+
+      reader.addEventListener('loadend', function() {
+        var segment = new Uint8Array(reader.result);
 
         if (resetTransmuxer || !transmuxer) {
           createInitSegment = true;
@@ -289,75 +366,29 @@
             transmuxer = new muxjs.partial.Transmuxer({remux: false});
           }
 
-          transmuxer.on('data', function(event) {
-            if (event.type === outputType) {
-              remuxedSegments.push(event);
-              if (!partial) {
-                remuxedBytesLength += event.data.byteLength;
-                remuxedInitSegment = event.initSegment;
-              } else {
-                remuxedBytesLength += event.data.boxes.byteLength;
-                remuxedInitSegment = event.data.track.initSegment;
-              }
-            }
-          });
+          transmuxer.on('data', onData);
 
-          transmuxer.on('caption', function(caption) {
-            parsedCaptions = parsedCaptions.concat(caption);
-          });
+          transmuxer.on('caption', onCaption);
 
-          transmuxer.on('done', function () {
-            var offset = 0;
-            if (createInitSegment) {
-              bytes = new Uint8Array(remuxedInitSegment.byteLength + remuxedBytesLength)
-              bytes.set(remuxedInitSegment, offset);
-              offset += remuxedInitSegment.byteLength;
-              createInitSegment = false;
-            } else {
-              bytes = new Uint8Array(remuxedBytesLength);
-            }
-
-            for (j = 0, i = offset; j < remuxedSegments.length; j++) {
-              var boxData = partial ?
-                 boxData = remuxedSegments[j].data.boxes :
-                 boxData = remuxedSegments[j].data;
-
-              bytes.set(boxData, i);
-              i += boxData.byteLength;
-            }
-            remuxedSegments = [];
-            remuxedBytesLength = 0;
-
-            vjsParsed = muxjs.mp4.tools.inspect(bytes);
-            console.log('transmuxed', vjsParsed);
-
-            // clear old box info
-            dashBoxes.innerHTML = JSON.stringify(parsedCaptions, null, 2);
-            console.log('captions', parsedCaptions);
-
-            if ($('#m2ts-active').checked) {
-              prepareSourceBuffer(combined, outputType, function () {
-                console.log('appending...');
-                window.vjsBuffer.appendBuffer(bytes);
-                video.play();
-              });
-            }
-          });
+          transmuxer.on('done', onDone);
+          if (partial) {
+            transmuxer.on('partialdone', onDone);
+          }
         }
 
         transmuxer.push(segment);
-        if (!partial) {
-          transmuxer.flush();
-        } else {
+        if (partial) {
           transmuxer.partialFlush();
+        } else {
+          transmuxer.flush();
         }
-      });
+      }.bind(this));
 
       muxedName = this.files[0].name.replace('.ts', '.f4m');
       reader.readAsArrayBuffer(this.files[0]);
     }, false);
 
-    $('#dash-init').addEventListener('change', function() {
+    dashInit.addEventListener('change', function() {
       var reader = new FileReader();
       var init = this.files[0];
       var segment;
@@ -373,7 +404,7 @@
       reader.readAsArrayBuffer(init);
     }, false);
 
-    $('#dash-media').addEventListener('change', function() {
+    dashMedia.addEventListener('change', function() {
       var segment = this.files[0];
 
       if (segment === undefined) {
@@ -391,7 +422,7 @@
 
     }, false);
 
-    $('#parse-dash').addEventListener('click', function() {
+    parseDash.addEventListener('click', function() {
       if (initResult === undefined || segmentResult === undefined) {
         console.error('Either the init or media segment was not provided');
         return;
@@ -402,8 +433,9 @@
       var videoTrackIds = probe.videoTrackIds(initBytes);
       var timescales = probe.timescale(initBytes);
       var texifiedParsed;
+      var partialDash = $('#dash-partial').value;
 
-      captionParser.init();
+      captionParser.init({ isPartial: partialDash });
       dashParsed = captionParser.parse(segmentBytes, videoTrackIds, timescales);
 
       dashBoxes.innerHTML = JSON.stringify(dashParsed, null, 2);
@@ -415,6 +447,17 @@
       if (muxedData && muxedName) {
         return saveTA(muxedData, muxedName);
       }
+    });
+
+    $('#clear-muxed').addEventListener('click', function() {
+      muxedData = undefined;
+      muxedName = undefined;
+      m2ts.value = "";
+    });
+
+    $('#clear-dash').addEventListener('click', function() {
+      dashInit.value = "";
+      dashMedia.value = "";
     });
 
     $('#combined-output').addEventListener('change', function () {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -99,22 +99,38 @@ CaptionStream.prototype.push = function(event) {
   this.latestDts_ = event.dts;
 };
 
-CaptionStream.prototype.sortAndDispatchPackets = function(packets) {
+CaptionStream.prototype.flushStream = function(flushType) {
+  if (flushType !== 'flush' && flushType !== 'partialFlush') {
+    return;
+  }
+
+  var flushCCStreams = function(captionStream) {
+    captionStream.ccStreams_.forEach(function(cc) {
+      return flushType === 'flush' ? cc.flush() : cc.partialFlush();
+    }, captionStream);
+  };
+
+  // make sure we actually parsed captions before proceeding
+  if (!this.captionPackets_.length) {
+    flushCCStreams(this);
+    return;
+  }
+
   // In Chrome, the Array#sort function is not stable so add a
   // presortIndex that we can use to ensure we get a stable-sort
-  packets.forEach(function(elem, idx) {
+  this.captionPackets_.forEach(function(elem, idx) {
     elem.presortIndex = idx;
   });
 
   // sort caption byte-pairs based on their PTS values
-  packets.sort(function(a, b) {
+  this.captionPackets_.sort(function(a, b) {
     if (a.pts === b.pts) {
       return a.presortIndex - b.presortIndex;
     }
     return a.pts - b.pts;
   });
 
-  packets.forEach(function(packet) {
+  this.captionPackets_.forEach(function(packet) {
     if (packet.type < 2) {
       // Dispatch packet to the right Cea608Stream
       this.dispatchCea608Packet(packet);
@@ -122,42 +138,18 @@ CaptionStream.prototype.sortAndDispatchPackets = function(packets) {
     // this is where an 'else' would go for a dispatching packets
     // to a theoretical Cea708Stream that handles SERVICEn data
   }, this);
+
+  this.captionPackets_.length = 0;
+  flushCCStreams(this);
 };
 
 CaptionStream.prototype.flush = function() {
-  // make sure we actually parsed captions before proceeding
-  if (!this.captionPackets_.length) {
-    this.ccStreams_.forEach(function(cc) {
-      cc.flush();
-    }, this);
-    return;
-  }
-
-  this.sortAndDispatchPackets(this.captionPackets_);
-
-  this.captionPackets_.length = 0;
-  this.ccStreams_.forEach(function(cc) {
-    cc.flush();
-  }, this);
-  return;
+  return this.flushStream('flush');
 };
 
 // Only called if handling partial data
 CaptionStream.prototype.partialFlush = function() {
-  // make sure we actually parsed captions before proceeding
-  if (!this.captionPackets_.length) {
-    this.ccStreams_.forEach(function(cc) {
-      cc.partialFlush();
-    }, this);
-    return;
-  }
-
-  this.sortAndDispatchPackets(this.captionPackets_);
-
-  this.captionPackets_.length = 0;
-  this.ccStreams_.forEach(function(cc) {
-    cc.partialFlush();
-  }, this);
+  return this.flushStream('partialFlush');
 };
 
 CaptionStream.prototype.reset = function() {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -38,6 +38,7 @@ var CaptionStream = function() {
   // forward data and done events from CCs to this CaptionStream
   this.ccStreams_.forEach(function(cc) {
     cc.on('data', this.trigger.bind(this, 'data'));
+    cc.on('partialdone', this.trigger.bind(this, 'partialdone'));
     cc.on('done', this.trigger.bind(this, 'done'));
   }, this);
 
@@ -99,20 +100,16 @@ CaptionStream.prototype.push = function(event) {
   this.latestDts_ = event.dts;
 };
 
+CaptionStream.prototype.flushCCStreams = function(flushType) {
+  this.ccStreams_.forEach(function(cc) {
+    return flushType === 'flush' ? cc.flush() : cc.partialFlush();
+  }, this);
+};
+
 CaptionStream.prototype.flushStream = function(flushType) {
-  if (flushType !== 'flush' && flushType !== 'partialFlush') {
-    return;
-  }
-
-  var flushCCStreams = function(captionStream) {
-    captionStream.ccStreams_.forEach(function(cc) {
-      return flushType === 'flush' ? cc.flush() : cc.partialFlush();
-    }, captionStream);
-  };
-
   // make sure we actually parsed captions before proceeding
   if (!this.captionPackets_.length) {
-    flushCCStreams(this);
+    this.flushCCStreams(flushType);
     return;
   }
 
@@ -140,7 +137,7 @@ CaptionStream.prototype.flushStream = function(flushType) {
   }, this);
 
   this.captionPackets_.length = 0;
-  flushCCStreams(this);
+  this.flushCCStreams(flushType);
 };
 
 CaptionStream.prototype.flush = function() {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -99,6 +99,31 @@ CaptionStream.prototype.push = function(event) {
   this.latestDts_ = event.dts;
 };
 
+CaptionStream.prototype.sortAndDispatchPackets = function(packets) {
+  // In Chrome, the Array#sort function is not stable so add a
+  // presortIndex that we can use to ensure we get a stable-sort
+  packets.forEach(function(elem, idx) {
+    elem.presortIndex = idx;
+  });
+
+  // sort caption byte-pairs based on their PTS values
+  packets.sort(function(a, b) {
+    if (a.pts === b.pts) {
+      return a.presortIndex - b.presortIndex;
+    }
+    return a.pts - b.pts;
+  });
+
+  packets.forEach(function(packet) {
+    if (packet.type < 2) {
+      // Dispatch packet to the right Cea608Stream
+      this.dispatchCea608Packet(packet);
+    }
+    // this is where an 'else' would go for a dispatching packets
+    // to a theoretical Cea708Stream that handles SERVICEn data
+  }, this);
+};
+
 CaptionStream.prototype.flush = function() {
   // make sure we actually parsed captions before proceeding
   if (!this.captionPackets_.length) {
@@ -108,34 +133,31 @@ CaptionStream.prototype.flush = function() {
     return;
   }
 
-  // In Chrome, the Array#sort function is not stable so add a
-  // presortIndex that we can use to ensure we get a stable-sort
-  this.captionPackets_.forEach(function(elem, idx) {
-    elem.presortIndex = idx;
-  });
-
-  // sort caption byte-pairs based on their PTS values
-  this.captionPackets_.sort(function(a, b) {
-    if (a.pts === b.pts) {
-      return a.presortIndex - b.presortIndex;
-    }
-    return a.pts - b.pts;
-  });
-
-  this.captionPackets_.forEach(function(packet) {
-    if (packet.type < 2) {
-      // Dispatch packet to the right Cea608Stream
-      this.dispatchCea608Packet(packet);
-    }
-    // this is where an 'else' would go for a dispatching packets
-    // to a theoretical Cea708Stream that handles SERVICEn data
-  }, this);
+  this.sortAndDispatchPackets(this.captionPackets_);
 
   this.captionPackets_.length = 0;
   this.ccStreams_.forEach(function(cc) {
     cc.flush();
   }, this);
   return;
+};
+
+// Only called if handling partial data
+CaptionStream.prototype.partialFlush = function() {
+  // make sure we actually parsed captions before proceeding
+  if (!this.captionPackets_.length) {
+    this.ccStreams_.forEach(function(cc) {
+      cc.partialFlush();
+    }, this);
+    return;
+  }
+
+  this.sortAndDispatchPackets(this.captionPackets_);
+
+  this.captionPackets_.length = 0;
+  this.ccStreams_.forEach(function(cc) {
+    cc.partialFlush();
+  }, this);
 };
 
 CaptionStream.prototype.reset = function() {

--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -258,6 +258,8 @@ var CaptionParser = function() {
   var timescale;
   // Stores captions parsed so far
   var parsedCaptions;
+  // Stores whether we are receiving partial data or not
+  var parsingPartial;
 
   /**
     * A method to indicate whether a CaptionParser has been initalized
@@ -271,9 +273,10 @@ var CaptionParser = function() {
     * Initializes the underlying CaptionStream, SEI NAL parsing
     * and management, and caption collection
    **/
-  this.init = function() {
+  this.init = function(options) {
     captionStream = new CaptionStream();
     isInitialized = true;
+    parsingPartial = options ? options.isPartial : false;
 
     // Collect dispatched captions
     captionStream.on('data', function(event) {
@@ -380,7 +383,11 @@ var CaptionParser = function() {
       return null;
     }
 
-    captionStream.flush();
+    if (!parsingPartial) {
+      captionStream.flush();
+    } else {
+      captionStream.partialFlush();
+    }
   };
 
   /**

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -814,6 +814,8 @@ CoalesceStream = function(options, metadataStream) {
 
   if (typeof options.keepOriginalTimestamps === 'boolean') {
     this.keepOriginalTimestamps = options.keepOriginalTimestamps;
+  } else {
+    this.keepOriginalTimestamps = false;
   }
 
   this.pendingTracks = [];
@@ -864,6 +866,10 @@ CoalesceStream.prototype.flush = function(flushSource) {
       metadata: [],
       info: {}
     },
+    caption,
+    adjustedCaption,
+    id3,
+    adjustedId3Frame,
     initSegment,
     timelineStartPts = 0,
     i;
@@ -937,8 +943,8 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // Translate caption PTS times into second offsets to match the
   // video timeline for the segment, and add track info
   for (i = 0; i < this.pendingCaptions.length; i++) {
-    var caption = this.pendingCaptions[i];
-    var adjustedCaption = adjustCaptionTiming(
+    caption = this.pendingCaptions[i];
+    adjustedCaption = adjustCaptionTiming(
       caption, timelineStartPts, this.keepOriginalTimestamps);
 
     event.captionStreams[adjustedCaption.stream] = true;
@@ -948,8 +954,8 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // Translate ID3 frame PTS times into second offsets to match the
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
-    var id3 = this.pendingMetadata[i];
-    var adjustedId3Frame = adjustMetadataTiming(
+    id3 = this.pendingMetadata[i];
+    adjustedId3Frame = adjustMetadataTiming(
       id3, timelineStartPts, this.keepOriginalTimestamps);
 
     event.metadata.push(adjustedId3Frame);
@@ -975,7 +981,7 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // Ideally, this would happen immediately on parsing captions,
   // but we need to ensure that video data is sent back first
   for (i = 0; i < event.captions.length; i++) {
-    var caption = event.captions[i];
+    caption = event.captions[i];
 
     this.trigger('caption', caption);
   }
@@ -983,7 +989,7 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // Ideally, this would happen immediately on parsing the tag,
   // but we need to ensure that video data is sent back first
   for (i = 0; i < event.metadata.length; i++) {
-    var id3 = event.metadata[i];
+    id3 = event.metadata[i];
 
     this.trigger('id3Frame', id3);
   }

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -47,9 +47,7 @@ var VideoSegmentStream, AudioSegmentStream, Transmuxer, CoalesceStream;
 // Helper functions
 var
   arrayEquals,
-  sumFrameByteLengths,
-  adjustCaptionTiming,
-  adjustMetadataTiming;
+  sumFrameByteLengths;
 
 /**
  * Compare two arrays (even typed) for same-ness
@@ -88,55 +86,6 @@ sumFrameByteLengths = function(array) {
   }
 
   return sum;
-};
-
-/**
- * Adjust caption start and end times by the timeline pts values if
- * keepOriginalTimeStamps is false
- */
-adjustCaptionTiming = function(caption, timelineStartPts, keepOriginalTimestamps) {
-  var startTime;
-  var endTime;
-
-  if (typeof keepOriginalTimestamps !== 'boolean') {
-    return;
-  }
-
-  startTime = caption.startPts;
-  if (!keepOriginalTimestamps) {
-    startTime -= timelineStartPts;
-  }
-  caption.startTime = clock.videoTsToSeconds(startTime);
-
-  endTime = caption.endPts;
-  if (!keepOriginalTimestamps) {
-    endTime -= timelineStartPts;
-  }
-  caption.endTime = clock.videoTsToSeconds(endTime);
-
-  return caption;
-};
-
-/**
- * Adjust ID3 tag timing information by the timeline pts values if
- * keepOriginalTimestamps is false
- */
-adjustMetadataTiming = function(id3Frame, timelineStartPts, keepOriginalTimestamps) {
-  var cueTime;
-
-  if (typeof keepOriginalTimestamps !== 'boolean') {
-    return;
-  }
-
-  cueTime = id3Frame.pts;
-
-  if (!keepOriginalTimestamps) {
-    cueTime -= timelineStartPts;
-  }
-
-  id3Frame.cueTime = clock.videoTsToSeconds(cueTime);
-
-  return id3Frame;
 };
 
 /**
@@ -867,9 +816,7 @@ CoalesceStream.prototype.flush = function(flushSource) {
       info: {}
     },
     caption,
-    adjustedCaption,
     id3,
-    adjustedId3Frame,
     initSegment,
     timelineStartPts = 0,
     i;
@@ -944,21 +891,20 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // video timeline for the segment, and add track info
   for (i = 0; i < this.pendingCaptions.length; i++) {
     caption = this.pendingCaptions[i];
-    adjustedCaption = adjustCaptionTiming(
-      caption, timelineStartPts, this.keepOriginalTimestamps);
+    caption.startTime = clock.metadataTsToSeconds(caption.startPts, timelineStartPts, this.keepOriginalTimestamps);
+    caption.endTime = clock.metadataTsToSeconds(caption.endPts, timelineStartPts, this.keepOriginalTimestamps);
 
-    event.captionStreams[adjustedCaption.stream] = true;
-    event.captions.push(adjustedCaption);
+    event.captionStreams[caption.stream] = true;
+    event.captions.push(caption);
   }
 
   // Translate ID3 frame PTS times into second offsets to match the
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
     id3 = this.pendingMetadata[i];
-    adjustedId3Frame = adjustMetadataTiming(
-      id3, timelineStartPts, this.keepOriginalTimestamps);
+    id3.cueTime = clock.videoTsToSeconds(id3.pts, timelineStartPts, this.keepOriginalTimestamps);
 
-    event.metadata.push(adjustedId3Frame);
+    event.metadata.push(id3);
   }
 
   // We add this to every single emitted segment even though we only need
@@ -980,6 +926,7 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // Emit each caption to the outside world
   // Ideally, this would happen immediately on parsing captions,
   // but we need to ensure that video data is sent back first
+  // so that caption timing can be adjusted to match video timing
   for (i = 0; i < event.captions.length; i++) {
     caption = event.captions[i];
 
@@ -988,6 +935,7 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // Emit each id3 tag to the outside world
   // Ideally, this would happen immediately on parsing the tag,
   // but we need to ensure that video data is sent back first
+  // so that ID3 frame timing can be adjusted to match video timing
   for (i = 0; i < event.metadata.length; i++) {
     id3 = event.metadata[i];
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -742,6 +742,9 @@ VideoSegmentStream.prototype = new Stream();
  * A Stream that can combine multiple streams (ie. audio & video)
  * into a single output segment for MSE. Also supports audio-only
  * and video-only streams.
+ * @param options {object} transmuxer options object
+ * @param options.keepOriginalTimestamps {boolean} If true, keep the timestamps
+ *        in the source; false to adjust the first segment to start at media timeline start.
  */
 CoalesceStream = function(options, metadataStream) {
   // Number of Tracks per output segment
@@ -750,10 +753,16 @@ CoalesceStream = function(options, metadataStream) {
   this.numberOfTracks = 0;
   this.metadataStream = metadataStream;
 
+  options = options || {};
+
   if (typeof options.remux !== 'undefined') {
     this.remuxTracks = !!options.remux;
   } else {
     this.remuxTracks = true;
+  }
+
+  if (typeof options.keepOriginalTimestamps === 'boolean') {
+    this.keepOriginalTimestamps = options.keepOriginalTimestamps;
   }
 
   this.pendingTracks = [];
@@ -804,7 +813,6 @@ CoalesceStream.prototype.flush = function(flushSource) {
       metadata: [],
       info: {}
     },
-    caption,
     id3,
     initSegment,
     timelineStartPts = 0,
@@ -876,26 +884,43 @@ CoalesceStream.prototype.flush = function(flushSource) {
     offset += this.pendingBoxes[i].byteLength;
   }
 
-  // Translate caption PTS times into second offsets into the
+  // Translate caption PTS times into second offsets to match the
   // video timeline for the segment, and add track info
   for (i = 0; i < this.pendingCaptions.length; i++) {
-    caption = this.pendingCaptions[i];
-    caption.startTime = (caption.startPts - timelineStartPts);
-    caption.startTime /= 90e3;
-    caption.endTime = (caption.endPts - timelineStartPts);
-    caption.endTime /= 90e3;
+    var caption = this.pendingCaptions[i];
+    var startTime;
+    var endTime;
+
+    startTime = caption.startPts;
+    if (!this.keepOriginalTimestamps) {
+      startTime -= timelineStartPts;
+    }
+    caption.startTime = clock.videoTsToSeconds(startTime);
+
+    endTime = caption.endPts;
+    if (!this.keepOriginalTimestamps) {
+      endTime -= timelineStartPts;
+    }
+    caption.endTime = clock.videoTsToSeconds(endTime);
+
     event.captionStreams[caption.stream] = true;
     event.captions.push(caption);
   }
 
-  // Translate ID3 frame PTS times into second offsets into the
+  // Translate ID3 frame PTS times into second offsets to match the
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
     id3 = this.pendingMetadata[i];
-    id3.cueTime = (id3.pts - timelineStartPts);
+
+    id3.cueTime = id3.pts;
+    if (!this.keepOriginalTimestamps) {
+      id3.cueTime -= timelineStartPts;
+    }
     id3.cueTime /= 90e3;
+
     event.metadata.push(id3);
   }
+
   // We add this to every single emitted segment even though we only need
   // it for the first
   event.metadata.dispatchType = this.metadataStream.dispatchType;
@@ -1121,7 +1146,10 @@ Transmuxer = function(options) {
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
     var pipeline = this.transmuxPipeline_;
 
-    this.baseMediaDecodeTime = baseMediaDecodeTime;
+    if (!options.keepOriginalTimestamps) {
+      this.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
+
     if (audioTrack) {
       audioTrack.timelineStartInfo.dts = undefined;
       audioTrack.timelineStartInfo.pts = undefined;

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -47,7 +47,9 @@ var VideoSegmentStream, AudioSegmentStream, Transmuxer, CoalesceStream;
 // Helper functions
 var
   arrayEquals,
-  sumFrameByteLengths;
+  sumFrameByteLengths,
+  adjustCaptionTiming,
+  adjustMetadataTiming;
 
 /**
  * Compare two arrays (even typed) for same-ness
@@ -86,6 +88,55 @@ sumFrameByteLengths = function(array) {
   }
 
   return sum;
+};
+
+/**
+ * Adjust caption start and end times by the timeline pts values if
+ * keepOriginalTimeStamps is false
+ */
+adjustCaptionTiming = function(caption, timelineStartPts, keepOriginalTimestamps) {
+  var startTime;
+  var endTime;
+
+  if (typeof keepOriginalTimestamps !== 'boolean') {
+    return;
+  }
+
+  startTime = caption.startPts;
+  if (!keepOriginalTimestamps) {
+    startTime -= timelineStartPts;
+  }
+  caption.startTime = clock.videoTsToSeconds(startTime);
+
+  endTime = caption.endPts;
+  if (!keepOriginalTimestamps) {
+    endTime -= timelineStartPts;
+  }
+  caption.endTime = clock.videoTsToSeconds(endTime);
+
+  return caption;
+};
+
+/**
+ * Adjust ID3 tag timing information by the timeline pts values if
+ * keepOriginalTimestamps is false
+ */
+adjustMetadataTiming = function(id3Frame, timelineStartPts, keepOriginalTimestamps) {
+  var cueTime;
+
+  if (typeof keepOriginalTimestamps !== 'boolean') {
+    return;
+  }
+
+  cueTime = id3Frame.pts;
+
+  if (!keepOriginalTimestamps) {
+    cueTime -= timelineStartPts;
+  }
+
+  id3Frame.cueTime = clock.videoTsToSeconds(cueTime);
+
+  return id3Frame;
 };
 
 /**
@@ -813,7 +864,6 @@ CoalesceStream.prototype.flush = function(flushSource) {
       metadata: [],
       info: {}
     },
-    id3,
     initSegment,
     timelineStartPts = 0,
     i;
@@ -888,37 +938,21 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // video timeline for the segment, and add track info
   for (i = 0; i < this.pendingCaptions.length; i++) {
     var caption = this.pendingCaptions[i];
-    var startTime;
-    var endTime;
+    var adjustedCaption = adjustCaptionTiming(
+      caption, timelineStartPts, this.keepOriginalTimestamps);
 
-    startTime = caption.startPts;
-    if (!this.keepOriginalTimestamps) {
-      startTime -= timelineStartPts;
-    }
-    caption.startTime = clock.videoTsToSeconds(startTime);
-
-    endTime = caption.endPts;
-    if (!this.keepOriginalTimestamps) {
-      endTime -= timelineStartPts;
-    }
-    caption.endTime = clock.videoTsToSeconds(endTime);
-
-    event.captionStreams[caption.stream] = true;
-    event.captions.push(caption);
+    event.captionStreams[adjustedCaption.stream] = true;
+    event.captions.push(adjustedCaption);
   }
 
   // Translate ID3 frame PTS times into second offsets to match the
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
-    id3 = this.pendingMetadata[i];
+    var id3 = this.pendingMetadata[i];
+    var adjustedId3Frame = adjustMetadataTiming(
+      id3, timelineStartPts, this.keepOriginalTimestamps);
 
-    id3.cueTime = id3.pts;
-    if (!this.keepOriginalTimestamps) {
-      id3.cueTime -= timelineStartPts;
-    }
-    id3.cueTime /= 90e3;
-
-    event.metadata.push(id3);
+    event.metadata.push(adjustedId3Frame);
   }
 
   // We add this to every single emitted segment even though we only need
@@ -934,7 +968,25 @@ CoalesceStream.prototype.flush = function(flushSource) {
   this.pendingMetadata.length = 0;
 
   // Emit the built segment
+  // We include captions and ID3 tags for backwards compatibility,
+  // ideally we should send only video and audio in the data event
   this.trigger('data', event);
+  // Emit each caption to the outside world
+  // Ideally, this would happen immediately on parsing captions,
+  // but we need to ensure that video data is sent back first
+  for (i = 0; i < event.captions.length; i++) {
+    var caption = event.captions[i];
+
+    this.trigger('caption', caption);
+  }
+  // Emit each id3 tag to the outside world
+  // Ideally, this would happen immediately on parsing the tag,
+  // but we need to ensure that video data is sent back first
+  for (i = 0; i < event.metadata.length; i++) {
+    var id3 = event.metadata[i];
+
+    this.trigger('id3Frame', id3);
+  }
 
   // Only emit `done` if all tracks have been flushed and emitted
   if (this.emittedTracks >= this.numberOfTracks) {
@@ -1138,6 +1190,12 @@ Transmuxer = function(options) {
 
     // Re-emit any data coming from the coalesce stream to the outside world
     pipeline.coalesceStream.on('data', this.trigger.bind(this, 'data'));
+    pipeline.coalesceStream.on('id3Frame', function(id3Frame) {
+      id3Frame.dispatchType = pipeline.metadataStream.dispatchType;
+
+      self.trigger('id3Frame', id3Frame);
+    });
+    pipeline.coalesceStream.on('caption', this.trigger.bind(this, 'caption'));
     // Let the consumer know we have finished flushing the entire pipeline
     pipeline.coalesceStream.on('done', this.trigger.bind(this, 'done'));
   };

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -51,7 +51,7 @@ var tsPipeline = function(options) {
 
   // Hook up CEA-608/708 caption stream
   pipeline.h264
-   .pipe(pipeline.captionStream);
+    .pipe(pipeline.captionStream);
 
   pipeline.elementary
     .pipe(pipeline.timedMetadataTimestampRolloverStream)

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -134,10 +134,6 @@ var tsPipeline = function(options) {
     });
   });
 
-  /* TODO caption support
-   * Caption support may be trickier than for full segment appends, as the captions can
-   * be split and processed in a much more granular fashion.
-  */
   pipeline.captionStream.on('data', function(caption) {
     var timelineStartPts;
     var startTime;
@@ -146,11 +142,13 @@ var tsPipeline = function(options) {
     if (pipeline.tracks.video) {
       timelineStartPts = pipeline.tracks.video.timelineStartInfo.pts || 0;
     } else {
+      // TODO: how do we handle the case where captions are returned before
+      // determining timelineStartPts?
       timelineStartPts = 0;
     }
 
     // Translate caption PTS times into second offsets into the
-    // video timeline for the segment, and add track info
+    // video timeline for the segment
     startTime = caption.startPts;
     if (!options.keepOriginalTimestamps) {
       startTime -= timelineStartPts;

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -142,10 +142,6 @@ var tsPipeline = function(options) {
     var timelineStartPts;
     var startTime;
     var endTime;
-    var event = {
-      captionStreams: {},
-      captions: []
-    };
 
     if (pipeline.tracks.video) {
       timelineStartPts = pipeline.tracks.video.timelineStartInfo.pts || 0;
@@ -167,10 +163,7 @@ var tsPipeline = function(options) {
     }
     caption.endTime = clock.videoTsToSeconds(endTime);
 
-    event.captionStreams[caption.stream] = true;
-    event.captions.push(caption);
-
-    pipeline.trigger('caption', event);
+    pipeline.trigger('caption', caption);
   });
 
   pipeline = createPipeline(pipeline);

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -138,7 +138,7 @@ var tsPipeline = function(options) {
    * Caption support may be trickier than for full segment appends, as the captions can
    * be split and processed in a much more granular fashion.
   */
-  pipeline.captionStream.on('data', function(captionInfo) {
+  pipeline.captionStream.on('data', function(caption) {
     var timelineStartPts;
     var startTime;
     var endTime;
@@ -155,22 +155,22 @@ var tsPipeline = function(options) {
 
     // Translate caption PTS times into second offsets into the
     // video timeline for the segment, and add track info
-    startTime = captionInfo.startPts;
+    startTime = caption.startPts;
     if (!options.keepOriginalTimestamps) {
       startTime -= timelineStartPts;
     }
-    captionInfo.startTime = clock.videoTsToSeconds(startTime);
+    caption.startTime = clock.videoTsToSeconds(startTime);
 
-    endTime = captionInfo.endPts;
+    endTime = caption.endPts;
     if (!options.keepOriginalTimestamps) {
       endTime -= timelineStartPts;
     }
-    captionInfo.endTime = clock.videoTsToSeconds(endTime);
+    caption.endTime = clock.videoTsToSeconds(endTime);
 
-    event.captionStreams[captionInfo.stream] = true;
-    event.captions.push(captionInfo);
+    event.captionStreams[caption.stream] = true;
+    event.captions.push(caption);
 
-    pipeline.trigger('captionInfo', event);
+    pipeline.trigger('caption', event);
   });
 
   pipeline = createPipeline(pipeline);
@@ -276,8 +276,8 @@ var setupPipelineListeners = function(pipeline, transmuxer) {
 
     transmuxer.trigger('id3Frame', event);
   });
-  pipeline.on('captionInfo', function(event) {
-    transmuxer.trigger('captionInfo', event);
+  pipeline.on('caption', function(event) {
+    transmuxer.trigger('caption', event);
   });
 };
 

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -140,17 +140,23 @@ var tsPipeline = function(options) {
   */
 
   pipeline.captionStream.on('data', function(captionInfo) {
+    if (!pipeline.tracks.video) {
+      console.log('TODO No timeline start pts');
+      return;
+    }
+
     var event = {
       captionStreams: {},
       captions: []
     };
+    var timelineStartPts = pipeline.tracks.video.timelineStartInfo.pts;
 
     // Translate caption PTS times into second offsets into the
     // video timeline for the segment, and add track info
     // FIXME: adjust timing here or later?
-    captionInfo.startTime = (captionInfo.startPts); //  - timelineStartPts);
+    captionInfo.startTime = (captionInfo.startPts - timelineStartPts);
     captionInfo.startTime /= 90e3;
-    captionInfo.endTime = (captionInfo.endPts); //  - timelineStartPts);
+    captionInfo.endTime = (captionInfo.endPts - timelineStartPts);
     captionInfo.endTime /= 90e3;
 
     event.captionStreams[captionInfo.stream] = true;

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -19,22 +19,22 @@ var createPipeline = function(object) {
 var tsPipeline = function(options) {
   var
     pipeline = {
-    type: 'ts',
-    tracks: {
-      audio: null,
-      video: null
-    },
-    packet: new m2ts.TransportPacketStream(),
-    parse: new m2ts.TransportParseStream(),
-    elementary: new m2ts.ElementaryStream(),
-    videoRollover: new m2ts.TimestampRolloverStream('video'),
-    audioRollover: new m2ts.TimestampRolloverStream('audio'),
-    adts: new codecs.Adts(),
-    h264: new codecs.h264.H264Stream(),
-    // captionStream: new m2ts.CaptionStream(),
-    metadataStream: new m2ts.MetadataStream(),
-    timedMetadataTimestampRolloverStream:
-      new m2ts.TimestampRolloverStream('timed-metadata')
+      type: 'ts',
+      tracks: {
+        audio: null,
+        video: null
+      },
+      packet: new m2ts.TransportPacketStream(),
+      parse: new m2ts.TransportParseStream(),
+      elementary: new m2ts.ElementaryStream(),
+      videoRollover: new m2ts.TimestampRolloverStream('video'),
+      audioRollover: new m2ts.TimestampRolloverStream('audio'),
+      adts: new codecs.Adts(),
+      h264: new codecs.h264.H264Stream(),
+      captionStream: new m2ts.CaptionStream(),
+      metadataStream: new m2ts.MetadataStream(),
+      timedMetadataTimestampRolloverStream:
+        new m2ts.TimestampRolloverStream('timed-metadata')
   };
 
   pipeline.headOfPipeline = pipeline.packet;
@@ -50,8 +50,8 @@ var tsPipeline = function(options) {
     .pipe(pipeline.h264);
 
   // Hook up CEA-608/708 caption stream
-  // pipeline.h264Stream
-  //  .pipe(pipeline.captionStream)
+  pipeline.h264
+   .pipe(pipeline.captionStream);
 
   pipeline.elementary
     .pipe(pipeline.timedMetadataTimestampRolloverStream)
@@ -137,24 +137,27 @@ var tsPipeline = function(options) {
   /* TODO caption support
    * Caption support may be trickier than for full segment appends, as the captions can
    * be split and processed in a much more granular fashion.
-  pipeline.captionStream.on('data', function(data) {
-    pendingCaptions.push(data);
-  });
+  */
 
-  pipeline.captionStream.on('flush', function() {
+  pipeline.captionStream.on('data', function(captionInfo) {
+    var event = {
+      captionStreams: {},
+      captions: []
+    };
+
     // Translate caption PTS times into second offsets into the
     // video timeline for the segment, and add track info
-    for (i = 0; i < this.pendingCaptions.length; i++) {
-      caption = this.pendingCaptions[i];
-      caption.startTime = (caption.startPts - timelineStartPts);
-      caption.startTime /= 90e3;
-      caption.endTime = (caption.endPts - timelineStartPts);
-      caption.endTime /= 90e3;
-      event.captionStreams[caption.stream] = true;
-      event.captions.push(caption);
-    }
+    // FIXME: adjust timing here or later?
+    captionInfo.startTime = (captionInfo.startPts); //  - timelineStartPts);
+    captionInfo.startTime /= 90e3;
+    captionInfo.endTime = (captionInfo.endPts); //  - timelineStartPts);
+    captionInfo.endTime /= 90e3;
+
+    event.captionStreams[captionInfo.stream] = true;
+    event.captions.push(captionInfo);
+
+    pipeline.trigger('captionInfo', event);
   });
-  */
 
   pipeline = createPipeline(pipeline);
 
@@ -258,6 +261,9 @@ var setupPipelineListeners = function(pipeline, transmuxer) {
     event.cueTime = clock.videoTsToSeconds(event.pts);
 
     transmuxer.trigger('id3Frame', event);
+  });
+  pipeline.on('captionInfo', function(event) {
+    transmuxer.trigger('captionInfo', event);
   });
 };
 

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -136,30 +136,20 @@ var tsPipeline = function(options) {
 
   pipeline.captionStream.on('data', function(caption) {
     var timelineStartPts;
-    var startTime;
-    var endTime;
 
     if (pipeline.tracks.video) {
       timelineStartPts = pipeline.tracks.video.timelineStartInfo.pts || 0;
     } else {
-      // TODO: how do we handle the case where captions are returned before
-      // determining timelineStartPts?
+      // This will only happen if we encounter caption packets before
+      // video data in a segment. This is an unusual/unlikely scenario,
+      // so we assume the timeline starts at zero for now.
       timelineStartPts = 0;
     }
 
     // Translate caption PTS times into second offsets into the
     // video timeline for the segment
-    startTime = caption.startPts;
-    if (!options.keepOriginalTimestamps) {
-      startTime -= timelineStartPts;
-    }
-    caption.startTime = clock.videoTsToSeconds(startTime);
-
-    endTime = caption.endPts;
-    if (!options.keepOriginalTimestamps) {
-      endTime -= timelineStartPts;
-    }
-    caption.endTime = clock.videoTsToSeconds(endTime);
+    caption.startTime = clock.metadataTsToSeconds(caption.startPts, timelineStartPts, options.keepOriginalTimestamps);
+    caption.endTime = clock.metadataTsToSeconds(caption.endPts, timelineStartPts, options.keepOriginalTimestamps);
 
     pipeline.trigger('caption', caption);
   });

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -138,26 +138,34 @@ var tsPipeline = function(options) {
    * Caption support may be trickier than for full segment appends, as the captions can
    * be split and processed in a much more granular fashion.
   */
-
   pipeline.captionStream.on('data', function(captionInfo) {
-    if (!pipeline.tracks.video) {
-      console.log('TODO No timeline start pts');
-      return;
-    }
-
+    var timelineStartPts;
+    var startTime;
+    var endTime;
     var event = {
       captionStreams: {},
       captions: []
     };
-    var timelineStartPts = pipeline.tracks.video.timelineStartInfo.pts;
+
+    if (pipeline.tracks.video) {
+      timelineStartPts = pipeline.tracks.video.timelineStartInfo.pts || 0;
+    } else {
+      timelineStartPts = 0;
+    }
 
     // Translate caption PTS times into second offsets into the
     // video timeline for the segment, and add track info
-    // FIXME: adjust timing here or later?
-    captionInfo.startTime = (captionInfo.startPts - timelineStartPts);
-    captionInfo.startTime /= 90e3;
-    captionInfo.endTime = (captionInfo.endPts - timelineStartPts);
-    captionInfo.endTime /= 90e3;
+    startTime = captionInfo.startPts;
+    if (!options.keepOriginalTimestamps) {
+      startTime -= timelineStartPts;
+    }
+    captionInfo.startTime = clock.videoTsToSeconds(startTime);
+
+    endTime = captionInfo.endPts;
+    if (!options.keepOriginalTimestamps) {
+      endTime -= timelineStartPts;
+    }
+    captionInfo.endTime = clock.videoTsToSeconds(endTime);
 
     event.captionStreams[captionInfo.stream] = true;
     event.captions.push(captionInfo);
@@ -331,7 +339,9 @@ var Transmuxer = function(options) {
   };
 
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
-    options.baseMediaDecodeTime = baseMediaDecodeTime;
+    if (!options.keepOriginalTimestamps) {
+      options.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
 
     if (!pipeline) {
       return;

--- a/lib/utils/clock.js
+++ b/lib/utils/clock.js
@@ -37,13 +37,7 @@ videoTsToAudioTs = function(timestamp, sampleRate) {
  * (if keepOriginalTimestamps is false) and convert to seconds
  */
 metadataTsToSeconds = function(timestamp, timelineStartPts, keepOriginalTimestamps) {
-  var newTimestamp = timestamp;
-
-  if (!keepOriginalTimestamps) {
-    newTimestamp -= timelineStartPts;
-  }
-
-  return videoTsToSeconds(newTimestamp);
+  return videoTsToSeconds(keepOriginalTimestamps ? timestamp : timestamp - timelineStartPts);
 };
 
 module.exports = {

--- a/lib/utils/clock.js
+++ b/lib/utils/clock.js
@@ -5,7 +5,8 @@ var
   videoTsToSeconds,
   audioTsToSeconds,
   audioTsToVideoTs,
-  videoTsToAudioTs;
+  videoTsToAudioTs,
+  metadataTsToSeconds;
 
 secondsToVideoTs = function(seconds) {
   return seconds * ONE_SECOND_IN_TS;
@@ -31,11 +32,26 @@ videoTsToAudioTs = function(timestamp, sampleRate) {
   return secondsToAudioTs(videoTsToSeconds(timestamp), sampleRate);
 };
 
+/**
+ * Adjust ID3 tag or caption timing information by the timeline pts values
+ * (if keepOriginalTimestamps is false) and convert to seconds
+ */
+metadataTsToSeconds = function(timestamp, timelineStartPts, keepOriginalTimestamps) {
+  var newTimestamp = timestamp;
+
+  if (!keepOriginalTimestamps) {
+    newTimestamp -= timelineStartPts;
+  }
+
+  return videoTsToSeconds(newTimestamp);
+};
+
 module.exports = {
   secondsToVideoTs: secondsToVideoTs,
   secondsToAudioTs: secondsToAudioTs,
   videoTsToSeconds: videoTsToSeconds,
   audioTsToSeconds: audioTsToSeconds,
   audioTsToVideoTs: audioTsToVideoTs,
-  videoTsToAudioTs: videoTsToAudioTs
+  videoTsToAudioTs: videoTsToAudioTs,
+  metadataTsToSeconds: metadataTsToSeconds
 };

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3050,7 +3050,7 @@ QUnit.test('can specify that we want to generate separate audio and video segmen
   QUnit.equal('mdat', boxes[1].type, 'generated a mdat box');
 });
 
-QUnit.test("doesn't adjust caption and ID3 times when configured to adjust timestamps", function() {
+QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps', function() {
   var transmuxer = new Transmuxer({ keepOriginalTimestamps: false });
 
   var

--- a/test/utils.clock.test.js
+++ b/test/utils.clock.test.js
@@ -161,3 +161,21 @@ QUnit.test('converts from video timestamp to audio timestamp', function() {
               4410,
               'converts video timestamp to audio timestamp');
 });
+
+QUnit.test('converts from metadata timestamp to seconds', function() {
+  QUnit.equal(clock.metadataTsToSeconds(90000, 90000, false),
+              0,
+              'converts metadata timestamp to seconds and adjusts by timelineStartPts');
+
+  QUnit.equal(clock.metadataTsToSeconds(270000, 90000, false),
+              2,
+              'converts metadata timestamp to seconds and adjusts by timelineStartPts');
+
+  QUnit.equal(clock.metadataTsToSeconds(90000, 90000, true),
+              1,
+              'converts metadata timestamp to seconds while keeping original timestamps');
+
+  QUnit.equal(clock.metadataTsToSeconds(180000, 0, true),
+              2,
+              'converts metadata timestamp to seconds while keeping original timestamps');
+});


### PR DESCRIPTION
## Description
This extends Partial Transmuxer to return caption data extracted from partial segments.

Pairs with [VHS PR](https://github.com/gesinger/http-streaming/pull/2). 

*Note*: This is currently against the working `transmux-pre-append-lhls` branch.

## Specific Changes proposed
- extend CaptionStream to also respond to partialFlush events from Partial Transmuxer
- extend CaptionParser to also respond to partialFlush events from Partial Transmuxer
- listen to events from CaptionStream to trigger time-adjusted caption data as `caption` events on the Partial (and full) Transmuxer
- update caption debugging page to work with both full and partial Transmuxers

## Documentation Needed
- Update caption docs to explain partialFlush/partialPush support
- Add/update Partial Transmuxer docs?

## Automated Tests Needed
- unit test on Partial Transmuxer to ensure that: 
  - [x] caption data timing is being adjusted appropriately by segment starting pts values
  - [ ] caption events are being triggered on the Partial Transmuxer when data is received from CaptionStream

## Manual Tests Needed
Look at [VHS PR](https://github.com/gesinger/http-streaming/pull/2) for testing instructions

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed and Tested
